### PR TITLE
use Sys.glob in getorderedfilelist

### DIFF
--- a/R/readutils.R
+++ b/R/readutils.R
@@ -8,7 +8,7 @@ readcmicor <- function(filename, colClasses=c("integer","integer","integer","num
 
 getorderedfilelist <- function(path="./", basename="onlinemeas", last.digits=4) {
 
-  ofiles <- dir(path=path, pattern=paste(basename, "*", sep=""))
+  ofiles <- Sys.glob( sprintf( "%s/%s*", path, basename ) ) 
   if(any(nchar(ofiles) != nchar(ofiles[1]))) {
     stop("we need all filenames to have the same length, aborting...\n")
   }


### PR DESCRIPTION
use Sys.glob instead of dir in getorderedfilelist, this way matching a .... character can be done because currently it seems that escaping it doesn't work when the argument is passed through multiple functions (probably because of 'paste')
