### PR TITLE
computefps.R: add option to reduce lattice artefacts in fps

### DIFF
--- a/R/computefps.R
+++ b/R/computefps.R
@@ -1,32 +1,51 @@
-computefps <- function(mfit, PP, mass, mu1, mu2, Kappa, normalisation="cmi") {
+computefps <- function(mfit, PP, mass, mu1, mu2, Kappa, normalisation="cmi", reduce.latarts=FALSE) {
   if(missing(mu1)) {
     stop("computefps: mu1  must be specified! Aborting...\n")
   }
   if(missing(mu2)) mu2 <- mu1
   if(missing(mfit)) {
-    if(normalisation != "cmi") return((mu1+mu2)/sqrt(2)*abs(PP)/sqrt(mass^3))
-    else return(2*Kappa*(mu1+mu2)/sqrt(2)*abs(PP)/sqrt(mass^3))
+    denominator <- sqrt(mass^3)
+    if(reduce.latarts) denominator <- sinh(mass)*sqrt(mass)
+    
+    if(normalisation != "cmi") return((mu1+mu2)/sqrt(2)*abs(PP)/denominator)
+    else return(2*Kappa*(mu1+mu2)/sqrt(2)*abs(PP)/denominator)
   }
   else if(any(class(mfit) == "matrixfit")) {
     k <- Kappa
     if(normalisation != "cmi") k <- 0.5
     else  mfit$kappa <- Kappa
-    mfit$fps <- 2*k*(mu1+mu2)/sqrt(2)*abs(mfit$opt.res$par[2])/sqrt(mfit$opt.res$par[1]^3)
-    mfit$fps.tsboot <- 2*k*(mu1+mu2)/sqrt(2)*abs(mfit$opt.tsboot[2,])/sqrt(mfit$opt.tsboot[1,]^3)
+    
+    denominator <- sqrt(mfit$opt.res$par[1]^3)
+    if(reduce.latarts) denominator <- sinh(mfit$opt.res$par[1])*sqrt(mfit$opt.res$par[1])
+    mfit$fps <- 2*k*(mu1+mu2)/sqrt(2)*abs(mfit$opt.res$par[2])/denominator
+
+    denominator <- sqrt(mfit$opt.tsboot[1,]^3)
+    if(reduce.latarts) denominator <- sinh(mfit$opt.tsboot[1,])*sqrt(mfit$opt.tsboot[1,])
+    mfit$fps.tsboot <- 2*k*(mu1+mu2)/sqrt(2)*abs(mfit$opt.tsboot[2,])/denominator
+
     mfit$mu1 <- mu1
     mfit$mu2 <- mu2
     mfit$normalisation <- normalisation
+    mfit$reduce.latarts <- reduce.latarts
     return(invisible(mfit))
   }
   else if(inherits(mfit, "gevp.amplitude")) {
     k <- Kappa
     if(normalisation != "cmi") k <- 0.5
     else  mfit$kappa <- Kappa
-    mfit$fps <- 2*k*(mu1+mu2)/sqrt(2)*abs(mfit$meanAmplitude)/sqrt(mfit$m0^3)
-    mfit$fps.tsboot <- 2*k*(mu1+mu2)/sqrt(2)*abs(mfit$meanAmplitude.tsboot[,1])/sqrt(mfit$m0.tsboot^3)
+
+    denominator <- sqrt(mfit$m0^3)
+    if(reduce.latarts) denominator <- sinh(mfit$m0)*sqrt(mfit$m0)
+    mfit$fps <- 2*k*(mu1+mu2)/sqrt(2)*abs(mfit$meanAmplitude)/denominator
+
+    denominator <- sqrt(mfit$m0.tsboot^3)
+    if(reduce.latarts) denominator <- sinh(mfit$m0.tsboot)*sqrt(mfit$m0.tsboot)
+    mfit$fps.tsboot <- 2*k*(mu1+mu2)/sqrt(2)*abs(mfit$meanAmplitude.tsboot[,1])/denominator
+    
     mfit$mu1 <- mu1
     mfit$mu2 <- mu2
     mfit$normalisation <- normalisation
+    mfit$reduce.latarts <- reduce.latarts
     return(invisible(mfit))
   }
   else{

--- a/man/computefps.Rd
+++ b/man/computefps.Rd
@@ -38,6 +38,12 @@ computefps(mfit, PP, mass, mu1, mu2, Kappa, normalistaion="cmi")
     normalisation of the correlators. If set to "cmi" the
     \eqn{\kappa}{kappa} value must be specified.
   }
+  \item{reduce.latarts}{
+    boolean which when set to \code{TRUE} causes the usage of a definition
+    of the decay constant involving mps*sinh(mps) rather
+    than mps^2 which reduces the effect of lattice artefacts
+    for heavy meson masses
+  }
 }
 \value{
   If \code{mfit} ist missing the value of fps will printed to stdout and
@@ -54,7 +60,14 @@ computefps(mfit, PP, mass, mu1, mu2, Kappa, normalistaion="cmi")
   for \code{normalisation="cmi"} or
   \deqn{f_\mathrm{PS} = (\mu_1+\mu_2)\frac{PP}{\sqrt{2}\sqrt{m_\mathrm{PS}}^3}}{%
     fps = (mu1+mu2) PP/sqrt(2)/sqrt(mps)^3}
-  expecting physical normalisation of the amplitudes.
+  expecting physical normalisation of the amplitudes.\cr
+  When \code{reduce.latarts=TRUE},\cr
+  \deqn{\sqrt{m_{\mathrm{PS}}^3}}{%
+    sqrt(mps^3)}
+  is replaced with
+  \deqn{\sqrt{m_{\mathrm{PS}}} \sinh{m_{\mathrm{PS}}}}{%
+    sqrt(mps)*sinh(mps))}
+  which reduces lattice artefacts for heavy meson masses.
 }
 \seealso{
   \link{\code{matrixfit}}, \link{\code{gevp2amplitude}}, \link{\code{pion}}


### PR DESCRIPTION
add boolean `reduce.latarts` argument to computefps which enables the usage of the definition of the decay constant which replaces `sqrt(mps^3)` with `sqrt( mps^2 sinh(mps) )`
