### PR TITLE
upon removal of columns, recompute inverse covariance matrix for error computation in effectivemass

### DIFF
--- a/R/effectivemass.R
+++ b/R/effectivemass.R
@@ -156,8 +156,15 @@ fit.effectivemass <- function(cf, t1, t2, useCov=FALSE, replace.na=TRUE) {
   if( length( ii.remove ) > 0 ) {
     # remove the columns that should be excluded from the fit below
     ii <- ii[ -ii.remove ]
-    # and restrict the covariance matrix accordingly
-    M <- M[ -ii.remove, -ii.remove]
+    # and treat the inverse covariance matrix accordingly
+    if(useCov) {
+      ## recompute covariance matrix and compute the correctly normalised inverse
+      ## note that we DON'T change the return value! (cf$invCovMatrix)
+      M <- invertCovMatrix(cf$effMass.tsboot[,ii], boot.samples=TRUE)
+    } else {
+      ## if the matrix is diagonal, we simply restrict it
+      M <- M[ -ii.remove, -ii.remove]
+    }
   }
 
   for(i in 1:cf$boot.R) {


### PR DESCRIPTION
fit.effectivemass: when resampling fails and columns are removed from the fit because there are too many NAs, the inverse covariance matrix needs to be recomputed and not just restricted
