### PR TITLE
plot.effectivemass: fix palette mangling and use colours directly

### DIFF
--- a/R/effectivemass.R
+++ b/R/effectivemass.R
@@ -219,7 +219,7 @@ print.effectivemassfit <- function(effMass, verbose=FALSE) {
 
 plot.effectivemass <- function(effMass, ref.value, col,...) {
   if(missing(col)) {
-    col <- c("black", palette(rainbow(max(effMass$nrObs,4))))
+    col <- c("black", rainbow(max(effMass$nrObs,4)))
   }
   op <- options()
   options(warn=-1)


### PR DESCRIPTION
In plot.effectivemass, using the palette function changes the global colour palette (essentially renumbering the fixed colour spectrum). This is an unintended bug and manifested itself as the "cyan" points from a 2x2 fit being drawn as black every second time the plot function was used in a given session.

The colours produced by rainbow should be used directly instead.
