### PR TITLE
plot.uwerr: x11 devices and histogram optional

### DIFF
--- a/R/UWerr.R
+++ b/R/UWerr.R
@@ -373,21 +373,21 @@ summary.uwerr <- function(uwerr) {
   }
 }
 
-plot.uwerr <- function(uwerr, main="x") {
-  if(uwerr$primary) {
-    X11()
+plot.uwerr <- function(uwerr, main="x", x11=TRUE, plot.hist=TRUE) {
+  if(uwerr$primary && plot.hist) {
+    if(x11) X11()
     hist(uwerr$data, main = paste("Histogram of" , main))
   }
   if(!is.null(uwerr$Gamma)) {
     GammaFbb <- uwerr$Gamma/uwerr$Gamma[1]
     Gamma.err <- gammaerror(Gamma=GammaFbb, N=uwerr$N , W=uwerr$Wmax, Lambda=100)
-    X11()
+    if(x11) X11()
     plotwitherror(c(0:uwerr$Wmax),GammaFbb[1:(uwerr$Wmax+1)],
                   Gamma.err[1:(uwerr$Wmax+1)], ylab="Gamma(t)", xlab="t", main=main)
     abline(v=uwerr$Wopt+1)
     abline(h=0)
   }
-  X11()
+  if(x11) X11()
   tauintplot(uwerr$tauintofW, uwerr$dtauintofW, uwerr$Wmax, uwerr$Wopt, main=main)  
   return(invisible(data.frame(t=c(0:uwerr$Wmax),Gamma=GammaFbb[1:(uwerr$Wmax+1)],dGamma=Gamma.err[1:(uwerr$Wmax+1)])))
 }


### PR DESCRIPTION
make creation of new x11 devices optional, make plotting of histogram optional

The former is practical when plotting to pdf and the latter when histograms are plotted elsewhere.
