### PR TITLE
fix links to make HTML documentation compileable

### DIFF
--- a/man/bootstrap.effectivemass.Rd
+++ b/man/bootstrap.effectivemass.Rd
@@ -12,15 +12,15 @@ type="solve", weight.factor=1)
 \arguments{
   \item{cf}{
     a correlation function as an object of type \code{cf}, preferably
-    after a call to \link{\code{bootstrap.cf}}. If the latter has not
+    after a call to \code{\link{bootstrap.cf}}. If the latter has not
     been called yet, it will be called in this function.
   }
   \item{boot.R}{
-    only used if no preceeding call to \link{\code{bootstrap.cf}} has
+    only used if no preceeding call to \code{\link{bootstrap.cf}} has
     happened and it counts the number of bootstrap samples.
   }
   \item{boot.l}{
-    only used if no preceeding call to \link{\code{bootstrap.cf}} has
+    only used if no preceeding call to \code{\link{bootstrap.cf}} has
     happened and it counts the bootstrap block length.
   }
   \item{seed}{
@@ -102,8 +102,8 @@ type="solve", weight.factor=1)
   arXiv:1203.6041
 }
 \seealso{
-  \link{\code{fit.effectivemass}}, \link{\code{bootstrap.cf}},
-  \link{\code{removeTemporal.cf}}
+  \code{\link{fit.effectivemass}}, \code{\link{bootstrap.cf}},
+  \code{\link{removeTemporal.cf}}
 }
 \examples{
 \dontrun{pion.pc1.effectivemass <- bootstrap.effectivemass(cf=pion.pc1, type="acosh")}

--- a/man/bootstrap.gevp.Rd
+++ b/man/bootstrap.gevp.Rd
@@ -46,15 +46,15 @@ element.order=c(1,2,3,4), seed=1234, sort.type="values")
 
   \code{cf}:\cr
   The input data, if needed bootstrapped with
-  \link{\code{bootstrap.cf}}.
+  \code{\link{bootstrap.cf}}.
 
   \code{res.gevp}:\cr
-  The object returned from the call to \link{\code{gevp}}. For the
-  format see \link{\code{gevp}}. 
+  The object returned from the call to \code{\link{gevp}}. For the
+  format see \code{\link{gevp}}. 
 
   \code{gevp.tsboot}:\cr
   The bootstrap samples of the GEVP. For the format see
-  \link{\code{gevp}}. 
+  \code{\link{gevp}}. 
 }
 \references{
   Michael, Christopher and Teasdale, I., Nucl.Phys.B215 (1983) 433, DOI:

--- a/man/computefps.Rd
+++ b/man/computefps.Rd
@@ -3,9 +3,9 @@
 \title{Computes the pseudoscalar decay constant for the twisted mass
   case from the pseudoscalar amplitude and mass}
 \description{
-  From a mass and amplitude determination (using \link{\code{matrixfit}}
-  or \link{\code{fit.effectivemass}}, \link{\code{bootstrap.gevp}} and
-  \link{\code{gevp2amplitude}} the pseudoscalar decay constant is
+  From a mass and amplitude determination (using \code{\link{matrixfit}}
+  or \code{\link{fit.effectivemass}}, \code{\link{bootstrap.gevp}} and
+  \code{\link{gevp2amplitude}} the pseudoscalar decay constant is
   determined for the case of Wilson twisted mass fermions from the
   pseudoscalar amplitude and mass
 }
@@ -15,8 +15,8 @@ computefps(mfit, PP, mass, mu1, mu2, Kappa, normalistaion="cmi")
 \arguments{
   \item{mfit}{
     An object of type \code{matrixfit} or \code{gevp.amplitude}
-    generated with \link{\code{matrixfit}} or
-    \link{\code{gevp2amplitude}}, respectively.
+    generated with \code{\link{matrixfit}} or
+    \code{\link{gevp2amplitude}}, respectively.
   }
   \item{PP}{
     If \code{mfit} is missing this must contain the value for the
@@ -77,7 +77,7 @@ computefps(mfit, PP, mass, mu1, mu2, Kappa, normalistaion="cmi")
   which can reduce lattice artefacts for heavy meson masses.
 }
 \seealso{
-  \link{\code{matrixfit}}, \link{\code{gevp2amplitude}}, \link{\code{pion}}
+  \code{\link{matrixfit}}, \code{\link{gevp2amplitude}}, \code{\link{pion}}
 }
 \author{Carsten Urbach, \email{curbach@gmx.de}}
 \keyword{GEVP}

--- a/man/effectivemass.cf.Rd
+++ b/man/effectivemass.cf.Rd
@@ -4,7 +4,7 @@
 \description{
   Computes effective mass values for a correlation function using
   different type of definitions for the effective mass. This function is
-  mainly indented for internal usage by \link{\code{bootstrap.effectivmass}}.
+  mainly indented for internal usage by \code{\link{bootstrap.effectivmass}}.
 }
 \usage{
 effectivemass.cf(cf, Thalf, type="solve", nrObs=1, replace.inf=TRUE,
@@ -36,12 +36,12 @@ interval=c(0.000001,2.), weight.factor=1)
     The number of "observables" included in the correlator
   }
   \item{replace.inf}{
-    If set to \code{TRUE}, all \link{\code{Inf}} values will be replaced
-    by \link{\code{NA}}. This is needed for instance for
-    \link{\code{bootstrap.effectivemass}}. 
+    If set to \code{TRUE}, all \code{\link{Inf}} values will be replaced
+    by \code{\link{NA}}. This is needed for instance for
+    \code{\link{bootstrap.effectivemass}}. 
   }
   \item{interval}{
-    initial interval for the \link{\code{root}} function when
+    initial interval for the \code{\link{root}} function when
     numerically solving for the effective mass.
   }
   \item{weight.factor}{
@@ -92,6 +92,6 @@ interval=c(0.000001,2.), weight.factor=1)
   arXiv:1203.6041
 }
 \seealso{
-  \link{\code{bootstrap.effectivemass}}
+  \code{\link{bootstrap.effectivemass}}
 }
 \author{Carsten Urbach, \email{curbach@gmx.de}}

--- a/man/extract.loop.Rd
+++ b/man/extract.loop.Rd
@@ -47,6 +47,6 @@ extract.loop(cmiloop, obs=9, ind.vec=c(2,3,4,5,6,7,8,1), L)
 
 }
 \seealso{
-  \link{\code{readcmiloopfiles}}
+  \code{\link{readcmiloopfiles}}
 }
 \author{Carsten Urbach, \email{curbach@gmx.de}}

--- a/man/fit.effectivemass.Rd
+++ b/man/fit.effectivemass.Rd
@@ -68,8 +68,8 @@ fit.effectivemass(effMass, t1=10, t2=20, useCov=TRUE, replace.na=TRUE, boot.fit=
   C.Michael, A.McKerrell,  Phys.Rev. D51 (1995) 3745-3750, hep-lat/9412087
 }
 \seealso{
-  \link{\code{bootstrap.effectivemass}}, \link{\code{boostrap.gevp}},
-  \link{\code{gevp2cf}}, \link{\code{invertCovMatrix}}
+  \code{\link{bootstrap.effectivemass}}, \code{\link{boostrap.gevp}},
+  \code{\link{gevp2cf}}, \code{\link{invertCovMatrix}}
 }
 \examples{
 \dontrun{pion.pc1.effectivemass <- bootstrap.effectivemass(cf=pion.pc1, type="acosh")}

--- a/man/gevp.Rd
+++ b/man/gevp.Rd
@@ -41,7 +41,7 @@ for.tsboot=TRUE, sort.type="values")
     \eqn{t=t_0+1}{t=t0+1}. Possible values are "values" or "vectors". 
   }
   \item{for.tsboot}{
-    for internal use of \link{\code{bootstrap.gevp}}. Alters the returned
+    for internal use of \code{\link{bootstrap.gevp}}. Alters the returned
     values, see details. 
   }
 }

--- a/man/gevp2amplitude.Rd
+++ b/man/gevp2amplitude.Rd
@@ -17,8 +17,8 @@ gevp2amplitude(gevp, mass, id=1, op.id=1, type="cosh", t1, t2, useCov)
   }
   \item{mass}{
     Optimally, this is an object either of class \code{effectivemassfit}
-    generated using \link{\code{fit.effectivemass}} or of class
-    \code{matrixfit} generated with \link{\code{matrixfit}} to the
+    generated using \code{\link{fit.effectivemass}} or of class
+    \code{matrixfit} generated with \code{\link{matrixfit}} to the
     principal correlator extracted using \code{\link{gevp2cf}} applied
     to \code{gevp} using the same value of \code{id}.
 
@@ -53,8 +53,8 @@ gevp2amplitude(gevp, mass, id=1, op.id=1, type="cosh", t1, t2, useCov)
 \details{
 }
 \seealso{
-  \link{\code{matrixfit}}, \link{\code{fit.effectivemass}},
-  \link{\code{gevp}}, \link{\code{gevp2cf}}, \link{\code{computefps}}
+  \code{\link{matrixfit}}, \code{\link{fit.effectivemass}},
+  \code{\link{gevp}}, \code{\link{gevp2cf}}, \code{\link{computefps}}
 }
 \examples{
 \dontrun{## apply a GEVP analysis}

--- a/man/gevp2cf.Rd
+++ b/man/gevp2cf.Rd
@@ -10,7 +10,7 @@ gevp2cf(gevp, id=1)
 }
 \arguments{
   \item{gevp}{
-    An object returned by \link{\code{bootstrap.gevp}}.
+    An object returned by \code{\link{bootstrap.gevp}}.
   }
   \item{id}{
     The index of the principal correlator to extract.
@@ -20,7 +20,7 @@ gevp2cf(gevp, id=1)
   An object of class \code{cf}, which contains bootstrap samples
   already. So a call to \code{bootstrap.cf} is neither needed nor
   possible. It can be treated further by
-  \link{\code{bootstrap.effectivemass}} or \link{\code{matrixfit}} to
+  \code{\link{bootstrap.effectivemass}} or \code{\link{matrixfit}} to
   extract a mass value.
 }
 %\details{
@@ -28,7 +28,7 @@ gevp2cf(gevp, id=1)
 %\references{
 %}
 \seealso{
-  \link{\code{gevp}}, \link{\code{matrixfit}}, \link{\code{bootstrap.effectivemass}}
+  \code{\link{gevp}}, \code{\link{matrixfit}}, \code{\link{bootstrap.effectivemass}}
 }
 \examples{
 \dontrun{## apply a GEVP analysis}

--- a/man/invertCovMatrix.Rd
+++ b/man/invertCovMatrix.Rd
@@ -31,7 +31,7 @@ invertCovMatrix(cf, boot.l=1, boot.samples=FALSE)
 }
 \value{
   Returns the inverse covariance matrix as an object of class
-  \link{\code{matrix}}. 
+  \code{\link{matrix}}. 
 }
 \details{
   The inverse covariance matrix is estimated. If the number of
@@ -45,7 +45,7 @@ invertCovMatrix(cf, boot.l=1, boot.samples=FALSE)
   C.Michael, A.McKerrell,  Phys.Rev. D51 (1995) 3745-3750, hep-lat/9412087
 }
 \seealso{
-  \link{\code{cov}}, \link{\code{matrix}}
+  \code{\link{cov}}, \code{\link{matrix}}
 }
 \examples{
 \dontrun{M <- invertCovMatrix(effMass.tsboot, boot.samples=TRUE)}


### PR DESCRIPTION
In some of the Rd files the link format was the wrong way around, preventing the HTML documentation to be built (and any other format that supports hyperlinks)