### PR TITLE
fix behaviour of readcmifiles when 'obs' is passed with multiple values

### DIFF
--- a/R/readutils.R
+++ b/R/readutils.R
@@ -64,7 +64,7 @@ readcmifiles <- function(files, excludelist=c(""), skip, verbose=FALSE,
       ## read the data
       tmpdata <- read.table(files[i], colClasses=colClasses, skip=skip)
       if(reduce) {
-        tmpdata <- tmpdata[tmpdata[,obs.index] == obs,]
+        tmpdata <- tmpdata[tmpdata[,obs.index] %in% obs,]
       }
       ## sanity checks
       if(fLength < length(tmpdata$V1)) {


### PR DESCRIPTION
readutils: in readcmifiles, when obs is given to follow the 'reduce' code path, use the %in% operator rather than == to select the correct rows from the correlators so that it works correctly also for length(obs)>1