### PR TITLE
effectivemass: make shifted effectivemass consistent with shifted correlation function

### DIFF
--- a/R/effectivemass.R
+++ b/R/effectivemass.R
@@ -42,7 +42,8 @@ effectivemass.cf <- function(cf, Thalf, type="solve", nrObs=1, replace.inf=TRUE,
       if(type == "weighted") w <- weight.factor
       ## the t-dependence needs to be modified accordingly
       fn <- function(m, t, T, Ratio, w) {
-        return(Ratio - (exp(-m*t)+exp(-m*(T-t)) - w*exp(-m*(t+deltat))-w*exp(-m*(T-t-deltat))) / (exp(-m*(t-deltat))+exp(-m*(T-t+deltat)) - w*exp(-m*(t))-w*exp(-m*(T-t))  ) )
+        return(Ratio - ( ( exp(-m*(t+1))+exp(-m*(T-t-1)) - w*( exp(-m*(t+1-deltat))+exp(-m*(T-(t+1-deltat))) ) ) /
+                         ( exp(-m*t)+exp(-m*(T-t)) - w*( exp(-m*(t-deltat))+exp(-m*(T-(t-deltat))) ) ) ) ) 
       }
       for(i in t) {
         if(is.na(Ratio[i])) effMass[i] <- NA


### PR DESCRIPTION
the shifted correlation function is stored as ```C'[t+deltat] = C[t] - C[t+deltat]```, such that ```deltat``` in the functional form as it is used in the shifted effectivemass has a negative contribution

it should be checked that the weight factor is implemented correctly now