### PR TITLE
plot.cf was broken for unbootstrapped correlator because the setup

### DIFF
--- a/R/cf.R
+++ b/R/cf.R
@@ -100,14 +100,25 @@ uwerr.cf <- function(cf, absval=FALSE){
                 FUN=function(x){
                   data <- x
                   if(absval) data <- abs(x)
-                  uw <- uwerrprimary(data=data)
-                  c(value=uw$value, dvalue=uw$dvalue, ddvalue=uw$ddvalue,
-                    tauint=uw$tauint, dtauint=uw$dtauint)
+                  uw <- try(uwerrprimary(data=data), silent=TRUE)
+                  if(any( class(uw) == 'try-error' ) ){
+                    c(value=NA,
+                      dvalue=NA,
+                      ddvalue=NA,
+                      tauint=NA,
+                      dtauint=NA)
+                  } else {
+                    c(value=uw$value, 
+                      dvalue=uw$dvalue, 
+                      ddvalue=uw$ddvalue,
+                      tauint=uw$tauint, 
+                      dtauint=uw$dtauint)
+                  }
                 }
                 )
       ) 
   )
-  
+  uwcf <- cbind(t=(1:ncol(cf$cf))-1,uwcf)
   return(uwcf)
 }
 

--- a/R/cf.R
+++ b/R/cf.R
@@ -326,9 +326,6 @@ c.cf <- function(...) {
 }
 
 plot.cf <- function(cf, boot.R=400, boot.l=2, neg.vec, rep=FALSE, ...) {
-  if(missing(neg.vec)){
-    neg.vec <- rep(1,times=length(cf$cf0))
-  }
   if(is.null(cf$jackknife.samples)) {
     cf$jackknife.samples <- FALSE
   }
@@ -341,6 +338,9 @@ plot.cf <- function(cf, boot.R=400, boot.l=2, neg.vec, rep=FALSE, ...) {
   Err <- numeric(0)
   if(cf$boot.samples) Err <- cf$tsboot.se
   else if(cf$jackknife.samples) Err <- cf$jackknife.se
+  if(missing(neg.vec)){
+    neg.vec <- rep(1,times=length(cf$cf0))
+  }
 
   tmax <- cf$Time/2
   if( "symmetrised" %in% names(cf) ) {
@@ -348,7 +348,6 @@ plot.cf <- function(cf, boot.R=400, boot.l=2, neg.vec, rep=FALSE, ...) {
       tmax <- cf$Time-1
     }
   }
-
   plotwitherror(x=rep(c(0:(tmax)), times=length(cf$cf0)/(tmax+1)), y=neg.vec*cf$cf0, dy=Err, rep=rep, ...)
   return(invisible(data.frame(t=rep(c(0:tmax), times=length(cf$cf0)/(tmax+1)), CF=cf$cf0, Err=Err)))
 }


### PR DESCRIPTION
of the default value for neg.vec relied on the pre-existence of bootstrap samples